### PR TITLE
fix: error message of filter won't disappear when updated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,9 +42,13 @@ export const useValidation = <T, K extends keyof T>(validationClass: Newable<T>)
             );
 
             if (filter.length > 0) {
-                setErrors({
-                    ...validationErrors,
-                    ...validation
+
+                setErrors(currentErrors => {
+                    filter.forEach(key => delete currentErrors[key])
+                    return {
+                        ...currentErrors,
+                        ...validation
+                    }
                 });
             } else {
                 setErrors(validation);


### PR DESCRIPTION
Closes #9 

The idea to solve the issue, is to delete the past validation errors of the filter, and then readd it. This way, we don't risk having old values.